### PR TITLE
Fix worktree path resolution bug (Issue #65)

### DIFF
--- a/src/cc_orchestrator/database/crud.py
+++ b/src/cc_orchestrator/database/crud.py
@@ -517,6 +517,20 @@ class WorktreeCRUD:
         return worktree
 
     @staticmethod
+    def get_by_name(session: Session, name: str) -> Worktree | None:
+        """Get worktree by name.
+
+        Args:
+            session: Database session.
+            name: Worktree name.
+
+        Returns:
+            Worktree object or None if not found.
+        """
+        worktree = session.query(Worktree).filter(Worktree.name == name).first()
+        return worktree
+
+    @staticmethod
     def get_by_id(session: Session, worktree_id: int) -> Worktree:
         """Get worktree by ID.
 


### PR DESCRIPTION
## Summary

Fixes Issue #65 - Worktree status and remove commands now work correctly with worktree names instead of requiring full paths.

- Added `WorktreeCRUD.get_by_name()` method for database lookups by worktree name
- Updated `get_worktree_status()` to try name lookup first, then fall back to path resolution
- Updated `remove_worktree()` with the same name-first lookup logic
- Added comprehensive integration test that reproduces and verifies the fix for Issue #65 scenario

## Root Cause

The bug occurred because `os.path.abspath(path_or_id)` resolved paths relative to the current working directory instead of looking up the actual worktree path stored in the database. When users tried commands like `cc-orchestrator worktrees status test-worktree`, the code would look for `/Users/user/workspace/cc-orchestrator/test-worktree` (CWD + name) instead of the actual database path `/Users/user/workspace/worktrees/test-worktree`.

## Changes

**Database Layer** (`src/cc_orchestrator/database/crud.py`):
- Added `WorktreeCRUD.get_by_name()` method to look up worktrees by name
- Returns `Worktree | None` to handle not-found cases gracefully

**Service Layer** (`src/cc_orchestrator/core/worktree_service.py`):
- `get_worktree_status()`: Now tries name lookup first, falls back to absolute path
- `remove_worktree()`: Same lookup logic as status method
- Both methods now use the path from the database record for all git operations
- Added proper error handling when worktree is not found

**Tests** (`tests/integration/test_cli_worktrees_integration.py`, `tests/unit/test_worktree_service.py`):
- Added integration test `test_worktree_status_and_remove_by_name()` that specifically tests the Issue #65 bug scenario
- Test verifies commands work by name regardless of current working directory
- Updated existing unit tests to reflect new name-first lookup behavior

## Test Plan

- [x] All 7 worktree integration tests pass (including new Issue #65 test)
- [x] All 17 worktree service unit tests pass  
- [x] All 8 worktree CRUD tests pass
- [x] Type checking passes (mypy clean for modified files)
- [x] Linting passes (ruff clean)
- [x] Formatting passes (black clean)
- [x] Manual testing: status and remove commands work with worktree names from any directory

## Reviewer Checklist

- [ ] Verify integration test `test_worktree_status_and_remove_by_name` reproduces original bug scenario
- [ ] Test commands manually: create a worktree, change directories, verify status/remove work by name
- [ ] Confirm error messages are clear when worktree not found
- [ ] Verify backward compatibility: commands still work with absolute paths and IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)